### PR TITLE
fix: specify illuminance unit as "lx" for ZG-223Z

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -18061,7 +18061,7 @@ export const definitions: DefinitionWithExtend[] = [
         configure: tuya.configureMagicPacket,
         exposes: [
             e.enum("rainwater", ea.STATE, ["none", "raining"]).withDescription("Sensor rainwater status"),
-            e.illuminance().withUnit("x"),
+            e.illuminance().withUnit("lx"),
             e
                 .numeric("sensitivity", ea.STATE_SET)
                 .withValueMin(0)

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -1421,7 +1421,7 @@ export const definitions: DefinitionWithExtend[] = [
         fromZigbee: [tuya.fz.datapoints],
         toZigbee: [tuya.tz.datapoints],
         configure: tuya.configureMagicPacket,
-        exposes: [e.illuminance().withUnit("lx"), e.temperature(), e.humidity()],
+        exposes: [e.illuminance(), e.temperature(), e.humidity()],
         meta: {
             tuyaDatapoints: [
                 [2, "illuminance", tuya.valueConverter.raw],

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -18061,7 +18061,7 @@ export const definitions: DefinitionWithExtend[] = [
         configure: tuya.configureMagicPacket,
         exposes: [
             e.enum("rainwater", ea.STATE, ["none", "raining"]).withDescription("Sensor rainwater status"),
-            e.illuminance().withUnit("lx"),
+            e.illuminance(),
             e
                 .numeric("sensitivity", ea.STATE_SET)
                 .withValueMin(0)


### PR DESCRIPTION
The `illuminance` exposure for the ZG-223Z device in `tuya.ts` had incorrect unit 'x'. This update corrects that via `.withUnit("lx")